### PR TITLE
Proper commands handling ('/help' and others)

### DIFF
--- a/src/game/server/gamemodes/zcatch.cpp
+++ b/src/game/server/gamemodes/zcatch.cpp
@@ -165,7 +165,6 @@ void CGameControllerZCATCH::OnPlayerCommandImpl(class CPlayer* pPlayer, const ch
 			if (size == 1)
 			{
 				GameServer()->SendServerMessage(ofID, "========== Help ==========");
-				GameServer()->SendServerMessage(ofID, "/welcome - The message you get, when you join the server.");
 				GameServer()->SendServerMessage(ofID, "/rules - If you want to know about zCatch's ruleset.");
 				GameServer()->SendServerMessage(ofID, "/info - If to know about this mod's creators.");
 				GameServer()->SendServerMessage(ofID, "/help list - To see a list of all the help screens.");

--- a/src/game/server/gamemodes/zcatch.cpp
+++ b/src/game/server/gamemodes/zcatch.cpp
@@ -68,32 +68,35 @@ void CGameControllerZCATCH::InitRankingServer()
 
 void CGameControllerZCATCH::ChatCommandsOnInit()
 {
-	
-	// Add some important commands, client wont sort alphabetically!
-	CommandsManager()->AddCommand("help", "s", "See a list of commands to help you with you questions.", [this](class CPlayer *pPlayer, const char *pArgs){
-		int ID = pPlayer->GetCID();
-		OnChatMessage(ID, 0, ID, pArgs);
-	});
-	CommandsManager()->AddCommand("info", "", "See some information about the zCatch mod.", [this](class CPlayer *pPlayer, const char *pArgs){
-		int ID = pPlayer->GetCID();
-		OnChatMessage(ID, 0, ID, "/info");
-	});
-	CommandsManager()->AddCommand("rules", "", "A quick read about how zCatch is played.", [this](class CPlayer *pPlayer, const char *pArgs){
-		int ID = pPlayer->GetCID();
-		OnChatMessage(ID, 0, ID, "/rules");
-	});
-	
-	if (m_pRankingServer)
+	struct Command
 	{
-		CommandsManager()->AddCommand("top", "", "See the server's top players.", [this](class CPlayer *pPlayer, const char *pArgs){
-			int ID = pPlayer->GetCID();
-			OnChatMessage(ID, 0, ID, "/top");
-		});
+		const char* name;
+		const char* description;
+		bool enabled;
+	};
 
-		CommandsManager()->AddCommand("rank", "p", "See a player's ranking statistics.", [this](class CPlayer *pPlayer, const char *pArgs){
-			int ID = pPlayer->GetCID();
-			OnChatMessage(ID, 0, ID, pArgs);
-		});
+	bool isRankingEnabled = m_pRankingServer;
+
+	// Add all commands, client wont sort alphabetically!
+	Command commands[] = {
+		{"help", "See a list of commands to help you with you questions.", true},
+		{"info", "See some information about the zCatch mod.", true},
+		{"rules", "A quick read about how zCatch is played.", true},
+		{"release", "Release player. See '/help release' for more info.", true},
+		{"allmessages", "Enable or disable extra messages.", true},
+		{"top", "See the server's top players.", isRankingEnabled},
+		{"rank", "See a player's ranking statistics.", isRankingEnabled},
+	};
+
+	for (size_t i = 0; i != sizeof(commands) / sizeof(commands[0]); ++i)
+	{
+		if (commands[i].enabled)
+		{
+			const char* name = commands[i].name;
+			CommandsManager()->AddCommand(name, "", commands[i].description, [this, name](class CPlayer* pPlayer, const char* pArgs) {
+				OnPlayerCommandImpl(pPlayer, name, pArgs);
+			});
+		}
 	}
 }
 
@@ -121,228 +124,230 @@ void CGameControllerZCATCH::OnReset()
 	}
 }
 
-void CGameControllerZCATCH::OnChatMessage(int ofID, int Mode, int toID, const char *pText)
-{
-	// message doesn't start with /, then it's no command message
-	if(pText && pText[0] && pText[0] != '/')
-	{
-		CPlayer *pPlayer = GameServer()->m_apPlayers[ofID];
 
-		// check if player is allowed to chat handle auto mute.
-		// IsAllowedToChat also informs the player about him being muted.
-		if(pPlayer && GameServer()->IsAllowedToChat(ofID))
-		{
-			IGameController::OnChatMessage(ofID, Mode, toID, pText);
-		}
-		return;
-	}
+void CGameControllerZCATCH::OnPlayerCommandImpl(class CPlayer* pPlayer, const char* pCommandName, const char* pArgs)
+{
+	int ofID = pPlayer->GetCID();
 
 	// parse words as tokens
-	std::stringstream commandLine(pText + 1);
+	std::stringstream commandLine(pArgs);
 	std::string tmpString;
 	std::vector<std::string> tokens;
+	tokens.push_back(pCommandName);
 
-	while(std::getline(commandLine, tmpString, ' ')) 
-    { 
-        tokens.push_back(tmpString); 
-    } 
-	int size = tokens.size();
-
-	if (size > 0)
+	while (std::getline(commandLine, tmpString, ' '))
 	{
-		try
+		tokens.push_back(tmpString);
+	}
+	size_t size = tokens.size();
+
+	try
+	{
+		if (tokens[0] == "help")
 		{
-			if(tokens[0] == "welcome")
+			if (size == 1)
 			{
-				GameServer()->SendServerMessageText(ofID, "Welcome to zCatch, where you kill all of your enemies to win a round. Write '/help' for more information.");
+				GameServer()->SendServerMessage(ofID, "========== Help ==========");
+				GameServer()->SendServerMessage(ofID, "/welcome - The message you get, when you join the server.");
+				GameServer()->SendServerMessage(ofID, "/rules - If you want to know about zCatch's ruleset.");
+				GameServer()->SendServerMessage(ofID, "/info - If to know about this mod's creators.");
+				GameServer()->SendServerMessage(ofID, "/help list - To see a list of all the help screens.");
+
 			}
-			else if (tokens[0] == "help")
+			else if (size >= 2)
 			{
-				if (size == 1)
+				if(tokens[1] == "list")
 				{
-					GameServer()->SendServerMessage(ofID, "========== Help ==========");
-					GameServer()->SendServerMessage(ofID, "/welcome - The message you get, when you join the server.");
-					GameServer()->SendServerMessage(ofID, "/rules - If you want to know about zCatch's ruleset.");
-					GameServer()->SendServerMessage(ofID, "/info - If to know about this mod's creators.");
-					GameServer()->SendServerMessage(ofID, "/help list - To see a list of all the help screens.");
-
+					GameServer()->SendServerMessage(ofID, "========== Help - List ==========");
+					GameServer()->SendServerMessageText(ofID, "/help release - Learn how to release players.");
+					GameServer()->SendServerMessageText(ofID, "/help warmup - Learn more about how the warmup works.");
+					GameServer()->SendServerMessageText(ofID, "/help anticamper - More about how the anti camper works.");
+					GameServer()->SendServerMessageText(ofID, "/help servermessages - How to enable more detailed information.");
+					GameServer()->SendServerMessageText(ofID, "/help ranking - Some information about the ranking.");
+					GameServer()->SendServerMessageText(ofID, "/help definitions [general|grenade|laser] - A list of zCatch terminology.");
 				}
-				else if (size >= 2)
+				else if(tokens[1] == "release")
 				{
-					if(tokens[1] == "list")
-					{
-						GameServer()->SendServerMessage(ofID, "========== Help - List ==========");
-						GameServer()->SendServerMessageText(ofID, "/help release - Learn how to release players.");
-						GameServer()->SendServerMessageText(ofID, "/help warmup - Learn more about how the warmup works.");
-						GameServer()->SendServerMessageText(ofID, "/help anticamper - More about how the anti camper works.");
-						GameServer()->SendServerMessageText(ofID, "/help servermessages - How to enable more detailed information.");
-						GameServer()->SendServerMessageText(ofID, "/help ranking - Some information about the ranking.");
-						GameServer()->SendServerMessageText(ofID, "/help definitions [general|grenade|laser] - A list of zCatch terminology.");
-					}
-					else if(tokens[1] == "release")
-					{
-						GameServer()->SendServerMessage(ofID, "========== Release ==========");
-						GameServer()->SendServerMessageText(ofID, "First off, releasing other players is optional and is a way of improving fair play.");
-						GameServer()->SendServerMessage(ofID, "There are two ways to release a player, that you have caught:");
-						GameServer()->SendServerMessageText(ofID, "The first one is to create a suicide bind like this 'bind k kill' using the F1 console. The second way is to write '/release' in the chat. The difference between both methods is that if you use your kill bind, you will kill yourself if nobody is left to be released. In contrast, the second method will not do anything if there is nobody left to be released.");
-					}
-					else if(tokens[1] == "warmup")
-					{
-						GameServer()->SendServerMessage(ofID, "========== Warmup ==========");
-						char aBuf[128];
-						str_format(aBuf, sizeof(aBuf), "As long as there are less than %d players ingame, warmup is enabled.", g_Config.m_SvPlayersToStartRound);
-						GameServer()->SendServerMessage(ofID, aBuf);
+					GameServer()->SendServerMessage(ofID, "========== Release ==========");
+					GameServer()->SendServerMessageText(ofID, "First off, releasing other players is optional and is a way of improving fair play.");
+					GameServer()->SendServerMessage(ofID, "There are two ways to release a player, that you have caught:");
+					GameServer()->SendServerMessageText(ofID, "The first one is to create a suicide bind like this 'bind k kill' using the F1 console. The second way is to write '/release' in the chat. The difference between both methods is that if you use your kill bind, you will kill yourself if nobody is left to be released. In contrast, the second method will not do anything if there is nobody left to be released.");
+				}
+				else if(tokens[1] == "warmup")
+				{
+					GameServer()->SendServerMessage(ofID, "========== Warmup ==========");
+					char aBuf[128];
+					str_format(aBuf, sizeof(aBuf), "As long as there are less than %d players ingame, warmup is enabled.", g_Config.m_SvPlayersToStartRound);
+					GameServer()->SendServerMessage(ofID, aBuf);
 
-						GameServer()->SendServerMessageText(ofID, "While in warmup, any player caught will respawn immediatly. If there are enough players for a round of zCatch, the warmup ends and players are caught normally.");
-					}
-					else if(tokens[1] == "anticamper")
+					GameServer()->SendServerMessageText(ofID, "While in warmup, any player caught will respawn immediatly. If there are enough players for a round of zCatch, the warmup ends and players are caught normally.");
+				}
+				else if(tokens[1] == "anticamper")
+				{
+					GameServer()->SendServerMessage(ofID, "========== Anti-Camper ==========");
+					char aBuf[128];
+					if(g_Config.m_SvAnticamperFreeze > 0)
 					{
-						GameServer()->SendServerMessage(ofID, "========== Anti-Camper ==========");
-						char aBuf[128];
-						if(g_Config.m_SvAnticamperFreeze > 0)
-						{
-							str_format(aBuf, sizeof(aBuf), "If you don't move for %d seconds out of the range of %d units, you will be freezed for %d seconds.", g_Config.m_SvAnticamperTime, g_Config.m_SvAnticamperRange, g_Config.m_SvAnticamperFreeze);
-						}
-						else
-						{
-							str_format(aBuf, sizeof(aBuf), "If you don't move for %d seconds out of the range of %d units, you will be killed.", g_Config.m_SvAnticamperTime, g_Config.m_SvAnticamperRange);
-						}
-						GameServer()->SendServerMessageText(ofID, aBuf);
-						str_format(aBuf, sizeof(aBuf), "Anticamper is currently %s.", g_Config.m_SvAnticamper > 0 ? "enabled" : "disabled");	
-						GameServer()->SendServerMessage(ofID, aBuf);
-					}
-					else if(tokens[1] == "servermessages")
-					{
-						GameServer()->SendServerMessage(ofID, "========== All Messages ==========");
-						GameServer()->SendServerMessageText(ofID, "Type /allmessages to get all of the information about your and other player's deaths.");
-						GameServer()->SendServerMessageText(ofID, "Type /allmessages again, in order to disable the extra information again.");
-					}
-					else if (tokens[1] == "ranking")
-					{
-						GameServer()->SendServerMessage(ofID, "========== Ranking ==========");
-						bool rankingEnabled = m_pRankingServer != nullptr;
-						if(rankingEnabled)
-							GameServer()->SendServerMessage(ofID, "Ranking is currently enabled on this server.");
-						else
-							GameServer()->SendServerMessage(ofID, "There is currently no player ranking enabled.");
-
-						GameServer()->SendServerMessageText(ofID, "The player ranking saves some of your playing statistics in a database. You can see your own statistics by typing the command /rank in the chat. If you want to see somone else's statistics, write /rank <nickname> instead. In order to see the top players on the server, use the /top command.");
-					}
-					else if(tokens[1] == "definitions" && size == 2)
-					{
-						GameServer()->SendServerMessage(ofID, "========== Definitions ==========");
-						GameServer()->SendServerMessageText(ofID, "/help definitions general - A list of general terminology for all zCatch modes.");
-						GameServer()->SendServerMessageText(ofID, "/help definitions grenade - A list of zCatch Grenade only terminology.");
-						GameServer()->SendServerMessageText(ofID, "/help definitions laser - A list of zCatch Laser only terminology.");
-					}
-					else if(tokens[1] == "definitions" && size >= 3)
-					{
-						if (tokens[2] == "general")
-						{
-							GameServer()->SendServerMessage(ofID, "========== Definitions - General ==========");
-							GameServer()->SendServerMessageText(ofID, "Camping : Waiting for an extended period in the same location(not necessary position) in order to easily catch an enemy.");
-							GameServer()->SendServerMessageText(ofID, "Flooding : Sending a excessive amount of, often similar, chat messages(also called chat spam).");
-							GameServer()->SendServerMessageText(ofID, "AFK : Being [A]way [F]rom the [K]eyboard for an extended period of time. It is appropriate to move these players to the spectator's team via vote.");
-						}
-						else if(tokens[2] == "grenade")
-						{
-							GameServer()->SendServerMessage(ofID, "========== Definitions - Grenade ==========");
-							GameServer()->SendServerMessageText(ofID, "Spamming : Shooting an excessive amount of grenades, often without properly aiming.");
-							GameServer()->SendServerMessageText(ofID, "Spraying : Shooting one or more grenades without seeing a player's position or predicting his position, often random shooting in order to hit someone that might luckily pass by.(also called random nade). It is appropriate to release the randomly caught player. Forward facing boost fades are considered as spraying, if they hit a target without hitting the speeding player at the same time. Backwards facing boost nades are not considered as spraying.");
-							GameServer()->SendServerMessageText(ofID, "Lucky Shot: Hitting a player, while aiming and shooting at another player is not considered as spraying, but it is appropriate to release the caught player.");
-						}
-						else if(tokens[2] == "laser")
-						{
-							GameServer()->SendServerMessage(ofID, "========== Definitions - Laser ==========");
-							GameServer()->SendServerMessageText(ofID, "zCatch Laser has no extraordinary terminology, other than the gerneral one.");
+						str_format(aBuf, sizeof(aBuf), "If you don't move for %d seconds out of the range of %d units, you will be freezed for %d seconds.", g_Config.m_SvAnticamperTime, g_Config.m_SvAnticamperRange, g_Config.m_SvAnticamperFreeze);
 					}
 					else
 					{
-							// unknown second token
+						str_format(aBuf, sizeof(aBuf), "If you don't move for %d seconds out of the range of %d units, you will be killed.", g_Config.m_SvAnticamperTime, g_Config.m_SvAnticamperRange);
+					}
+					GameServer()->SendServerMessageText(ofID, aBuf);
+					str_format(aBuf, sizeof(aBuf), "Anticamper is currently %s.", g_Config.m_SvAnticamper > 0 ? "enabled" : "disabled");
+					GameServer()->SendServerMessage(ofID, aBuf);
+				}
+				else if(tokens[1] == "servermessages")
+				{
+					GameServer()->SendServerMessage(ofID, "========== All Messages ==========");
+					GameServer()->SendServerMessageText(ofID, "Type /allmessages to get all of the information about your and other player's deaths.");
+					GameServer()->SendServerMessageText(ofID, "Type /allmessages again, in order to disable the extra information again.");
+				}
+				else if (tokens[1] == "ranking")
+				{
+					GameServer()->SendServerMessage(ofID, "========== Ranking ==========");
+					bool rankingEnabled = m_pRankingServer != nullptr;
+					if(rankingEnabled)
+						GameServer()->SendServerMessage(ofID, "Ranking is currently enabled on this server.");
+					else
+						GameServer()->SendServerMessage(ofID, "There is currently no player ranking enabled.");
+
+					GameServer()->SendServerMessageText(ofID, "The player ranking saves some of your playing statistics in a database. You can see your own statistics by typing the command /rank in the chat. If you want to see somone else's statistics, write /rank <nickname> instead. In order to see the top players on the server, use the /top command.");
+				}
+				else if(tokens[1] == "definitions" && size == 2)
+				{
+					GameServer()->SendServerMessage(ofID, "========== Definitions ==========");
+					GameServer()->SendServerMessageText(ofID, "/help definitions general - A list of general terminology for all zCatch modes.");
+					GameServer()->SendServerMessageText(ofID, "/help definitions grenade - A list of zCatch Grenade only terminology.");
+					GameServer()->SendServerMessageText(ofID, "/help definitions laser - A list of zCatch Laser only terminology.");
+				}
+				else if(tokens[1] == "definitions" && size >= 3)
+				{
+					if (tokens[2] == "general")
+					{
+						GameServer()->SendServerMessage(ofID, "========== Definitions - General ==========");
+						GameServer()->SendServerMessageText(ofID, "Camping : Waiting for an extended period in the same location(not necessary position) in order to easily catch an enemy.");
+						GameServer()->SendServerMessageText(ofID, "Flooding : Sending a excessive amount of, often similar, chat messages(also called chat spam).");
+						GameServer()->SendServerMessageText(ofID, "AFK : Being [A]way [F]rom the [K]eyboard for an extended period of time. It is appropriate to move these players to the spectator's team via vote.");
+					}
+					else if(tokens[2] == "grenade")
+					{
+						GameServer()->SendServerMessage(ofID, "========== Definitions - Grenade ==========");
+						GameServer()->SendServerMessageText(ofID, "Spamming : Shooting an excessive amount of grenades, often without properly aiming.");
+						GameServer()->SendServerMessageText(ofID, "Spraying : Shooting one or more grenades without seeing a player's position or predicting his position, often random shooting in order to hit someone that might luckily pass by.(also called random nade). It is appropriate to release the randomly caught player. Forward facing boost fades are considered as spraying, if they hit a target without hitting the speeding player at the same time. Backwards facing boost nades are not considered as spraying.");
+						GameServer()->SendServerMessageText(ofID, "Lucky Shot: Hitting a player, while aiming and shooting at another player is not considered as spraying, but it is appropriate to release the caught player.");
+					}
+					else if(tokens[2] == "laser")
+					{
+						GameServer()->SendServerMessage(ofID, "========== Definitions - Laser ==========");
+						GameServer()->SendServerMessageText(ofID, "zCatch Laser has no extraordinary terminology, other than the gerneral one.");
+					}
+					else
+					{
+						// unknown second token
 						throw std::invalid_argument("");
 					}
 				}
-					
-				else
-				{
-					throw std::invalid_argument("");
-				}
-				}
-				else
-				{
-					throw std::invalid_argument("");
-				}
-			}
-			else if (tokens[0] == "info" && size == 1)
-			{
-				GameServer()->SendServerMessage(ofID, "========== Info  ==========");
-				GameServer()->SendServerMessageText(ofID, "Welcome to zCatch, a completely newly created version for Teeworlds 0.7. The ground work was done erdbaer & Teetime and is used as reference. Teelevision did a great job maintaining the mod after the Instagib Laser era. Also a thank you to TeeSlayer, who ported a basic version of zCatch to Teeworlds 0.7, that has also been used as reference.");
 
-				GameServer()->SendServerMessage(ofID, "This zCatch modification is being created by jxsl13.");
-			}
-			else if(tokens[0] == "rules")
-			{  
-				GameServer()->SendServerMessage(ofID, "========== Rules ==========");
-				GameServer()->SendServerMessageText(ofID, "zCatch is a Last Man Standing game mode. The last player to be alive will win the round. Each player killed by you is considered as caught. If you die, all of your caught players are released. If you catch all of them, you win the round. As a measure of fair play, you are able to release your caught players manually in reverse order. Releasing players is optional in zCatch. Type '/help release' for more information.");
-				
-			}
-			else if(tokens[0] == "release" && size == 1)
-			{
-				class CPlayer *pPlayer = GameServer()->m_apPlayers[ofID];
-				if(pPlayer)
-				{
-					pPlayer->ReleaseLastCaughtPlayer(CPlayer::REASON_PLAYER_RELEASED, true);
-				}
-			}
-			else if(tokens[0] == "allmessages")
-			{
-				class CPlayer *pPlayer = GameServer()->m_apPlayers[ofID];
-				bool isAlreadyDetailed = pPlayer->m_DetailedServerMessages;
-				if(isAlreadyDetailed)
-				{
-					pPlayer->m_DetailedServerMessages = false;
-					GameServer()->SendServerMessage(ofID, "Disabled detailed server messages.");
-				}
 				else
 				{
-					pPlayer->m_DetailedServerMessages = true;
-					GameServer()->SendServerMessage(ofID, "Enabled detailed server messages.");
+					throw std::invalid_argument("");
 				}
-			}
-			else if(tokens[0] == "rank")
-			{
-				if(size > 1)
-				{
-					std::string cmd{pText + 1};
-        			auto pos = cmd.find_first_of(' ');
-					std::string nickname = cmd.substr(pos+1, std::string::npos);
-					// ofID requests the data of nickname(ss.str())
-					RequestRankingData(ofID, nickname);
-				}
-				else
-				{
-					// size == 1
-					// request your own ranking data
-					RequestRankingData(ofID, {Server()->ClientName(ofID)});
-				}
-			}
-			else if (tokens[0] == "top")
-			{
-				RequestTopRankingData(ofID, "Score");
 			}
 			else
 			{
 				throw std::invalid_argument("");
 			}
 		}
-		catch (const std::invalid_argument&)
+		else if (tokens[0] == "info" && size == 1)
 		{
-			GameServer()->SendServerMessage(ofID, "No such command, please try /help");
+			GameServer()->SendServerMessage(ofID, "========== Info  ==========");
+			GameServer()->SendServerMessageText(ofID, "Welcome to zCatch, a completely newly created version for Teeworlds 0.7. The ground work was done erdbaer & Teetime and is used as reference. Teelevision did a great job maintaining the mod after the Instagib Laser era. Also a thank you to TeeSlayer, who ported a basic version of zCatch to Teeworlds 0.7, that has also been used as reference.");
+
+			GameServer()->SendServerMessage(ofID, "This zCatch modification is being created by jxsl13.");
+		}
+		else if(tokens[0] == "rules")
+		{
+			GameServer()->SendServerMessage(ofID, "========== Rules ==========");
+			GameServer()->SendServerMessageText(ofID, "zCatch is a Last Man Standing game mode. The last player to be alive will win the round. Each player killed by you is considered as caught. If you die, all of your caught players are released. If you catch all of them, you win the round. As a measure of fair play, you are able to release your caught players manually in reverse order. Releasing players is optional in zCatch. Type '/help release' for more information.");
+
+		}
+		else if(tokens[0] == "release" && size == 1)
+		{
+			class CPlayer *pPlayer = GameServer()->m_apPlayers[ofID];
+			if(pPlayer)
+			{
+				pPlayer->ReleaseLastCaughtPlayer(CPlayer::REASON_PLAYER_RELEASED, true);
+			}
+		}
+		else if(tokens[0] == "allmessages")
+		{
+			class CPlayer *pPlayer = GameServer()->m_apPlayers[ofID];
+			bool isAlreadyDetailed = pPlayer->m_DetailedServerMessages;
+			if(isAlreadyDetailed)
+			{
+				pPlayer->m_DetailedServerMessages = false;
+				GameServer()->SendServerMessage(ofID, "Disabled detailed server messages.");
+			}
+			else
+			{
+				pPlayer->m_DetailedServerMessages = true;
+				GameServer()->SendServerMessage(ofID, "Enabled detailed server messages.");
+			}
+		}
+		else if(tokens[0] == "rank")
+		{
+			if(size > 1)
+			{
+				std::string nickname = tokens[1];
+				// ofID requests the data of nickname(ss.str())
+				RequestRankingData(ofID, nickname);
+			}
+			else
+			{
+				// size == 1
+				// request your own ranking data
+				RequestRankingData(ofID, {Server()->ClientName(ofID)});
+			}
+		}
+		else if (tokens[0] == "top")
+		{
+			RequestTopRankingData(ofID, "Score");
+		}
+		else
+		{
+			throw std::invalid_argument("");
 		}
 	}
-	else
+	catch (const std::invalid_argument&)
+	{
+		GameServer()->SendServerMessage(ofID, "No such command, please try /help");
+	}
+}
+
+void CGameControllerZCATCH::OnChatMessage(int ofID, int Mode, int toID, const char *pText)
+{
+	if (!pText)
 	{
 		return;
+	}
+	
+	// If messages starts with /, player send some unexistent command. 
+	// So, help player with available commands. 
+	if(pText[0] == '/')
+	{
+		GameServer()->SendServerMessage(ofID, "No such command, please try /help");
+		return;
+	}
+
+	CPlayer *pPlayer = GameServer()->m_apPlayers[ofID];
+
+	// check if player is allowed to chat handle auto mute.
+	// IsAllowedToChat also informs the player about him being muted.
+	if(pPlayer && GameServer()->IsAllowedToChat(ofID))
+	{
+		IGameController::OnChatMessage(ofID, Mode, toID, pText);
 	}
 }
 
@@ -704,7 +709,7 @@ void CGameControllerZCATCH::OnPlayerConnect(class CPlayer *pPlayer)
 	RetrieveRankingData(ID);
 
 	// greeting
-	OnChatMessage(ID, 0, ID, "/welcome");
+	GameServer()->SendServerMessageText(ID, "Welcome to zCatch, where you kill all of your enemies to win a round. Write '/help' for more information.");
 	
 	// warmup
 	if (IsGameWarmup())

--- a/src/game/server/gamemodes/zcatch.h
+++ b/src/game/server/gamemodes/zcatch.h
@@ -252,7 +252,8 @@ private:
 	// send chat command messages
 	void ChatCommandsOnPlayerConnect(CPlayer* pPlayer);
 
-
+	// Handle comand (/release, /help etc.)
+	void OnPlayerCommandImpl(class CPlayer* pPlayer, const char* pCommandName, const char* pArgs);
 };
 
 #endif


### PR DESCRIPTION
There are were some problems at least with current steam client (0.7.5): 
- player can't use `/help` because it declared with `'s'` specifier. TW client rejects sending `/help` message because it expects string argument;
- case `/help someting`  was handled incorrectly. Instead of printing help info about 'something' actual behaviour was printing `something` in common chat. It's happened because then calling `OnChatMessage(ID, 0, ID, pArgs);` `pArgs` doesn't prefixed with `/help ` ;
- also `/rank` command was not recognized as command in TW client (then you press `/` in chat you can view list of commands) because in modern TW client there is no `'p'` (player) specifier. It was removed in [this](https://github.com/teeworlds/teeworlds/commit/c366b3f7050ba8380c519b5eece3c3794af79879) commit.

You can check these problems in game.

This pull request have following changes:
- greeting message don't use `OnChatMessage` anymore (it was quite strange);
- all commands registred in `CommandsManager()` now, so it visible in TW client (`release` and `allmessages` were added);
- handling commands was moved into `OnPlayerCommandImpl`;
- all specifiers for commands are removed;

--
bleeding